### PR TITLE
Convert demo rad toy model to CCPP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ccpp_framework"]
+	path = ccpp_framework
+	url = https://github.com/gold2718/ccpp-framework

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,89 @@
 cmake_minimum_required(VERSION 3.1)
-project(demo-radiation Fortran)
+project(demo_rad Fortran)
+
+#-----------------------------------------------------------------------------
+#
+# Set where the CCPP Framework lives
+#
+#-----------------------------------------------------------------------------
+SET(TOY_ROOT "${CMAKE_SOURCE_DIR}")
+SET(TOY_SRC "${TOY_ROOT}/src")
+
+SET(CCPP_ROOT "${TOY_ROOT}/ccpp_framework")
+SET(CCPP_FRAMEWORK ${CCPP_ROOT}/scripts)
+
+################################################################################
+# Configure CCPP
+# The chemistry suite schemes
+SET(SCHEME_METADATA "${TOY_SRC}/musica_schemes.txt")
+SET(HOST_METADATA "${TOY_SRC}/model.meta")
+SET(SUITE_FILES "${TOY_SRC}/toy_suite.xml")
+# HOST is the name of the executable we will build.
+SET(HOST "${CMAKE_PROJECT_NAME}")
+# By default, no verbose output
+SET(VERBOSITY 0 CACHE STRING "Verbosity level of output (default: 0)")
+# By default, generated caps go in ccpp subdir
+SET(CCPP_CAP_FILES "${CMAKE_BINARY_DIR}/ccpp" CACHE
+  STRING "Location of CCPP-generated cap files")
+
+SET(CCPP_FRAMEWORK ${CCPP_ROOT}/scripts)
+
+# Run CCPP Framework
+SET(CAPGEN_CMD "${CCPP_FRAMEWORK}/ccpp_capgen.py")
+LIST(APPEND CAPGEN_CMD "--host-files")
+LIST(APPEND CAPGEN_CMD "${HOST_METADATA}")
+LIST(APPEND CAPGEN_CMD "--scheme-files")
+LIST(APPEND CAPGEN_CMD "${SCHEME_METADATA}")
+LIST(APPEND CAPGEN_CMD "--suites")
+LIST(APPEND CAPGEN_CMD "${SUITE_FILES}")
+LIST(APPEND CAPGEN_CMD "--output-root")
+LIST(APPEND CAPGEN_CMD "${CCPP_CAP_FILES}")
+LIST(APPEND CAPGEN_CMD "--host-name")
+LIST(APPEND CAPGEN_CMD "${HOST}")
+while (VERBOSITY GREATER 0)
+  LIST(APPEND CAPGEN_CMD "--verbose")
+  MATH(EXPR VERBOSITY "${VERBOSITY} - 1")
+endwhile ()
+string(REPLACE ";" " " CAPGEN_STRING "${CAPGEN_CMD}")
+MESSAGE(STATUS "Running: ${CAPGEN_STRING}")
+EXECUTE_PROCESS(COMMAND ${CAPGEN_CMD} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE CAPGEN_OUT ERROR_VARIABLE CAPGEN_OUT RESULT_VARIABLE RES)
+MESSAGE(STATUS "${CAPGEN_OUT}")
+if (RES EQUAL 0)
+  MESSAGE(STATUS "CCPP cap generation completed")
+else(RES EQUAL 0)
+  MESSAGE(FATAL_ERROR "CCPP cap generation FAILED: result = ${RES}")
+endif(RES EQUAL 0)
+
+# Grab the CCPP generated files
+set(DTABLE_CMD "${CCPP_FRAMEWORK}/ccpp_datafile.py")
+list(APPEND DTABLE_CMD "${CCPP_CAP_FILES}/datatable.xml")
+list(APPEND DTABLE_CMD "--ccpp-files")
+list(APPEND DTABLE_CMD "--separator=\\;")
+string(REPLACE ";" " " DTABLE_STRING "${DTABLE_CMD}")
+MESSAGE(STATUS "Running: ${DTABLE_STRING}")
+EXECUTE_PROCESS(COMMAND ${DTABLE_CMD} OUTPUT_VARIABLE CCPP_CAPS
+                RESULT_VARIABLE RES
+                OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
+if (RES EQUAL 0)
+  MESSAGE(STATUS "CCPP cap files retrieved")
+else(RES EQUAL 0)
+  MESSAGE(FATAL_ERROR "CCPP cap file retrieval FAILED: result = ${RES}")
+endif(RES EQUAL 0)
+FOREACH(FILE ${CCPP_CAPS})
+  LIST(APPEND LIBRARY_LIST ${FILE})
+ENDFOREACH(FILE)
 
 ################################################################################
 # toy model with radiation
-file(GLOB DEMO_SRCS src/aerosol.F90
-                    src/aerosol_modal.F90
+file(GLOB DEMO_SRCS src/musica_aerosol.F90
+                    src/musica_aerosol_modal.F90
                     src/model.F90
-                    src/radiation.F90
+                    src/musica_radiation.F90
                     src/wavelength_grid.F90)
 
-add_executable(demo ${DEMO_SRCS})
+add_executable(demo ${DEMO_SRCS} ${LIBRARY_LIST})
 
-set_target_properties(demo PROPERTIES OUTPUT_NAME demo)
+set_target_properties(demo PROPERTIES OUTPUT_NAME "${HOST}")
 
 ################################################################################

--- a/src/model.F90
+++ b/src/model.F90
@@ -1,29 +1,80 @@
+module demo_rad_mod
+
+   implicit none
+   private
+
+   public :: demo_rad
+
+CONTAINS
+
+   !> \section arg_table_demo_rad  Argument Table
+   !! \htmlinclude arg_table_demo_rad.html
+   subroutine demo_rad()
+      use demo_rad_ccpp_cap, only: demo_rad_ccpp_physics_initialize
+      use demo_rad_ccpp_cap, only: demo_rad_ccpp_physics_timestep_initial
+      use demo_rad_ccpp_cap, only: demo_rad_ccpp_physics_run
+      use demo_rad_ccpp_cap, only: demo_rad_ccpp_physics_timestep_final
+      use demo_rad_ccpp_cap, only: demo_rad_ccpp_physics_finalize
+
+      integer                   :: i_time
+      integer                   :: errcode
+      integer                   :: col_start = 1
+      integer                   :: col_end = 1
+      character(len=512)        :: errmsg
+
+      ! Use the suite information to setup the run
+      call demo_rad_ccpp_physics_initialize('toy_suite', errmsg, errcode)
+      if (errcode /= 0) then
+         write(6, *) trim(errmsg)
+         write(6, *) 'An error occurred in ccpp_physics_init, Exiting...'
+         stop
+      end if
+
+      do i_time = 1, 5
+         ! Initialize the timestep
+         call demo_rad_ccpp_physics_timestep_initial('toy_suite',             &
+              errmsg, errcode)
+         if (errcode /= 0) then
+            write(6, *) trim(errmsg)
+            write(6, *) 'An error occurred in ccpp_physics_timestep_init, ",  &
+                 "Exiting...'
+            stop
+         end if
+
+         call demo_rad_ccpp_physics_run('toy_suite', 'chemistry', col_start,  &
+              col_end, errmsg, errcode)
+         if (errcode /= 0) then
+            write(6, *) trim(errmsg)
+            write(6, *) 'An error occurred in ccpp_physics_run, Exiting...'
+            stop
+         end if
+
+         call demo_rad_ccpp_physics_timestep_final('toy_suite', errmsg, errcode)
+         if (errcode /= 0) then
+            write(6, *) trim(errmsg)
+            write(6, *) 'An error occurred in ccpp_physics_timestep_final, ", &
+                 "Exiting...'
+            stop
+         end if
+
+      end do
+
+      call demo_rad_ccpp_physics_finalize('toy_suite', errmsg, errcode)
+      if (errcode /= 0) then
+         write(6, *) trim(errmsg)
+         write(6,'(a)') 'An error occurred in ccpp_physics_final, Exiting...'
+         stop
+      end if
+
+   end subroutine demo_rad
+
+end module demo_rad_mod
+
 ! the host model
 program model
+   use demo_rad_mod, only: demo_rad
+   implicit none
 
-  use musica_aerosol,                  only : aerosol_t
-  use musica_aerosol_modal,            only : aerosol_modal_t
-  use musica_radiation,                only : radiation_initialize, radiation_run
-
-  implicit none
-
-  class(aerosol_t), pointer :: aerosol
-  integer :: i_time
-
-  ! with CCPP, the aerosol_t object would probably be registered by an aerosol scheme
-  ! and exist as a standard-named variable?
-  aerosol => aerosol_modal_t()
-
-  ! this would be through the CCPP initialization of radiation
-  call radiation_initialize( aerosol )
-
-  ! time loop
-  do i_time = 1, 5
-
-    ! this would be through the CCPP run call to radiation
-    ! radiation would ask for the aerosol_t object as an argument to its run function
-    call radiation_run( aerosol )
-
-  end do
+   call demo_rad()
 
 end program model

--- a/src/model.meta
+++ b/src/model.meta
@@ -1,0 +1,29 @@
+[ccpp-table-properties]
+  name = demo_rad
+  type = host
+[ccpp-arg-table]
+  name = demo_rad
+  type = host
+[ col_start ]
+  standard_name = horizontal_loop_begin
+  type = integer
+  units = count
+  dimensions = ()
+[ col_end ]
+  standard_name = horizontal_loop_end
+  type = integer
+  units = count
+  dimensions = ()
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+[ errcode ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer

--- a/src/musica_aerosol.F90
+++ b/src/musica_aerosol.F90
@@ -7,6 +7,8 @@ module musica_aerosol
   public :: aerosol_t, material_optics_grid_t, material_optics_sample_t
 
   ! an aerosol state and diagnostics
+  !> \section arg_table_aerosol_t  Argument Table
+  !! \htmlinclude aerosol_t.html
   type, abstract :: aerosol_t
   contains
     procedure(get_optics_grid), deferred, private :: get_optics_grid

--- a/src/musica_aerosol.meta
+++ b/src/musica_aerosol.meta
@@ -1,0 +1,7 @@
+[ccpp-table-properties]
+  name = aerosol_t
+  type = ddt
+
+[ccpp-arg-table]
+  name  = aerosol_t
+  type  = ddt

--- a/src/musica_aerosol_modal.F90
+++ b/src/musica_aerosol_modal.F90
@@ -11,9 +11,14 @@ module musica_aerosol_modal
 
   public :: aerosol_modal_t
 
+  public :: aerosol_modal_init
+  public :: aerosol_modal_run
+
   ! a modal aerosol state and diagnostics
+  !> \section arg_table_aerosol_modal_t  Argument Table
+  !! \htmlinclude aerosol_modal_t.html
   type, extends( aerosol_t ) :: aerosol_modal_t
-    integer :: number_of_modes_
+    integer           :: number_of_modes_
     real, allocatable :: state_( : ) ! stand-in for mass, number, etc.
   contains
     procedure, private :: get_optics_grid
@@ -54,8 +59,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   function constructor( ) result( aerosol )
-    type( aerosol_modal_t ), pointer :: aerosol
-    allocate( aerosol )
+    type( aerosol_modal_t ) :: aerosol
     aerosol%number_of_modes_ = 3
     allocate( aerosol%state_( aerosol%number_of_modes_ ) )
     ! initialize other aerosol parameters
@@ -186,5 +190,26 @@ contains
   end subroutine sample_forward_scattering_optical_depth
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> \section arg_table_aerosol_modal_init  Argument Table
+  !! \htmlinclude aerosol_modal_init.html
+  subroutine aerosol_modal_init(aerosol, errcode, errmsg)
+    type(aerosol_modal_t), intent(out) :: aerosol
+    integer,               intent(out) :: errcode
+    character(len=512),    intent(out) :: errmsg
+
+    errcode = 0
+    errmsg = ''
+  end subroutine aerosol_modal_init
+
+  !> \section arg_table_aerosol_modal_run  Argument Table
+  !! \htmlinclude aerosol_modal_run.html
+  subroutine aerosol_modal_run(errcode, errmsg)
+    integer,               intent(out) :: errcode
+    character(len=512),    intent(out) :: errmsg
+
+    errcode = 0
+    errmsg = ''
+  end subroutine aerosol_modal_run
 
 end module musica_aerosol_modal

--- a/src/musica_aerosol_modal.meta
+++ b/src/musica_aerosol_modal.meta
@@ -1,0 +1,56 @@
+[ccpp-table-properties]
+  name = aerosol_modal_t
+  type = ddt
+  dependencies = musica_aerosol.F90,musica_wavelength_grid.F90
+
+[ccpp-arg-table]
+  name  = aerosol_modal_t
+  type  = ddt
+[ number_of_modes_ ]
+  standard_name = number_of_aerosol_modes
+  units = count
+  type = integer
+  dimensions = ()
+
+[ccpp-table-properties]
+  name = aerosol_modal
+  type = scheme
+  dependencies = musica_aerosol.F90,musica_wavelength_grid.F90
+
+[ccpp-arg-table]
+  name  = aerosol_modal_init
+  type  = scheme
+[ aerosol ]
+  standard_name = modal_aerosol_object
+  units = none
+  type = aerosol_modal_t
+  dimensions = ()
+  intent = out
+[ errcode ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = 1
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+
+[ccpp-arg-table]
+  name  = aerosol_modal_run
+  type  = scheme
+[ errcode ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = 1
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out

--- a/src/musica_radiation.F90
+++ b/src/musica_radiation.F90
@@ -9,7 +9,8 @@ module musica_radiation
   implicit none
   private
 
-  public :: radiation_initialize, radiation_run
+  public :: musica_radiation_initialize
+  public :: musica_radiation_run
 
   ! obviously not thread safe
   class( material_optics_grid_t ), pointer :: grid_optics
@@ -22,8 +23,14 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   ! this would be the CCPP initialize function for radiation
-  subroutine radiation_initialize( aerosol )
-    class( aerosol_t ), intent( in ) :: aerosol
+  !> \section arg_table_musica_radiation_initialize  Argument Table
+  !! \htmlinclude musica_radiation_initialize.html
+  subroutine musica_radiation_initialize(aerosol, errcode, errmsg)
+    ! Dummy arguments
+    class(aerosol_t),   intent(in)  :: aerosol
+    integer,            intent(out) :: errcode
+    character(len=512), intent(out) :: errmsg
+    ! Local variable
     type( wavelength_grid_t ) :: grid
 
     ! create the grid (with more options for setting grid dimensions)
@@ -34,22 +41,26 @@ contains
     ! get the optical depth calculators
     grid_optics => aerosol%get_optics( grid )
     optics_550nm => aerosol%get_optics( 550.0e-9 )
-  end subroutine radiation_initialize
+  end subroutine musica_radiation_initialize
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   ! this would be the CCPP run function for radiation
-  subroutine radiation_run( aerosol )
-    class( aerosol_t ), pointer :: aerosol
+  !> \section arg_table_musica_radiation_run  Argument Table
+  !! \htmlinclude musica_radiation_run.html
+  subroutine musica_radiation_run(aerosol, errcode, errmsg)
+    class(aerosol_t),   intent(in)  :: aerosol
+    integer,            intent(out) :: errcode
+    character(len=512), intent(out) :: errmsg
 
     ! calculate the optical depths
     call grid_optics%optical_depth( aerosol, optical_depths_on_grid )
     call optics_550nm%scattering_optical_depth( aerosol,                      &
             scattering_optical_depth_550nm )
 
-    write(*,*) "grid AOD", optical_depths_on_grid
-    write(*,*) "scattering AOD at 550 nm", scattering_optical_depth_550nm
-  end subroutine radiation_run
+    write(6, *) "grid AOD", optical_depths_on_grid
+    write(6, *) "scattering AOD at 550 nm", scattering_optical_depth_550nm
+  end subroutine musica_radiation_run
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/musica_radiation.meta
+++ b/src/musica_radiation.meta
@@ -1,0 +1,47 @@
+[ccpp-table-properties]
+  name = musica_radiation
+  type = scheme
+
+[ccpp-arg-table]
+  name  = musica_radiation_initialize
+  type  = scheme
+[ aerosol ]
+  standard_name = modal_aerosol_object
+  units = none
+  type = aerosol_t | polymorphic = True
+  dimensions = ()
+  intent = in
+[ errcode ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = 1
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+
+[ccpp-arg-table]
+  name  = musica_radiation_run
+  type  = scheme
+[ aerosol ]
+  standard_name = modal_aerosol_object
+  units = enter_units
+  type = aerosol_t
+  dimensions = ()
+  intent = in
+[ errcode ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = 1
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out

--- a/src/musica_schemes.txt
+++ b/src/musica_schemes.txt
@@ -1,0 +1,3 @@
+musica_aerosol.meta
+musica_aerosol_modal.meta
+musica_radiation.meta

--- a/src/toy_suite.xml
+++ b/src/toy_suite.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="toy_suite" version="1.0">
+  <group name="chemistry">
+    <scheme>aerosol_modal</scheme>
+    <scheme>musica_radiation</scheme>
+  </group>
+</suite>


### PR DESCRIPTION
This PR modifies the code structure so that the model operates as a CCPP model and suite.
- model.(F90,meta) is the CCPP host model
- musica_aerosol_modal.(F90,meta) and musica_radiation.(F90,meta) are the CCPP schemes
- musica_aerosol.(F90,meta) is processed by the CCPP Framework for the definition of the abstract base class
- toy_suite.xml is the CCPP suite

CMakeLists.txt has been updated to run the CCPP Framework and add the generated code to the build.